### PR TITLE
Add Flask-based text to CAD web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+generated/*.stl
+generated/*.step

--- a/app.py
+++ b/app.py
@@ -1,0 +1,69 @@
+import os
+import uuid
+from flask import Flask, request, jsonify, send_from_directory, render_template
+import cadquery as cq
+from cadquery import exporters
+
+app = Flask(__name__)
+GEN_DIR = os.path.join(os.path.dirname(__file__), 'generated')
+os.makedirs(GEN_DIR, exist_ok=True)
+
+
+def build_model(desc: str) -> cq.Workplane:
+    tokens = desc.lower().split()
+    if not tokens:
+        raise ValueError('Empty description')
+    shape = tokens[0]
+    args = list(map(float, tokens[1:]))
+    if shape in ('box', 'cube'):
+        if len(args) == 1:
+            w = h = d = args[0]
+        elif len(args) == 3:
+            w, h, d = args
+        else:
+            raise ValueError('box requires 1 or 3 dimensions')
+        return cq.Workplane('XY').box(w, h, d)
+    elif shape == 'cylinder':
+        if len(args) != 2:
+            raise ValueError('cylinder requires radius and height')
+        r, h = args
+        return cq.Workplane('XY').cylinder(h, r)
+    elif shape == 'sphere':
+        if len(args) != 1:
+            raise ValueError('sphere requires radius')
+        r = args[0]
+        return cq.Workplane('XY').sphere(r)
+    else:
+        raise ValueError(f'Unknown shape {shape}')
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/generate', methods=['POST'])
+def generate():
+    data = request.get_json(force=True)
+    desc = data.get('description', '')
+    try:
+        model = build_model(desc)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 400
+    file_id = str(uuid.uuid4())
+    stl_name = f'{file_id}.stl'
+    step_name = f'{file_id}.step'
+    stl_path = os.path.join(GEN_DIR, stl_name)
+    step_path = os.path.join(GEN_DIR, step_name)
+    exporters.export(model, stl_path)
+    exporters.export(model, step_path)
+    return jsonify({'preview': f'/generated/{stl_name}', 'step': f'/generated/{step_name}'})
+
+
+@app.route('/generated/<path:filename>')
+def serve_generated(filename: str):
+    return send_from_directory(GEN_DIR, filename, as_attachment=filename.endswith('.step'))
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Text to CAD</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.134/examples/js/loaders/STLLoader.js"></script>
+</head>
+<body>
+<h1>Text to CAD</h1>
+<input type="text" id="desc" placeholder="cube 10 10 10" size="40">
+<button onclick="generate()">Generate</button>
+<div id="viewer" style="width:600px;height:400px;"></div>
+<a id="download" href="#" download="model.step" style="display:none">Download STEP</a>
+<script>
+let scene, camera, renderer;
+function init(){
+    scene = new THREE.Scene();
+    camera = new THREE.PerspectiveCamera(75, 600/400, 0.1, 1000);
+    camera.position.z = 60;
+    renderer = new THREE.WebGLRenderer({antialias:true});
+    renderer.setSize(600, 400);
+    document.getElementById('viewer').appendChild(renderer.domElement);
+    const light = new THREE.DirectionalLight(0xffffff, 1);
+    light.position.set(0,0,1).normalize();
+    scene.add(light);
+    animate();
+}
+function animate(){
+    requestAnimationFrame(animate);
+    renderer.render(scene, camera);
+}
+function loadSTL(url){
+    while(scene.children.length>1) scene.remove(scene.children[1]);
+    const loader = new THREE.STLLoader();
+    loader.load(url, function(geometry){
+        const material = new THREE.MeshNormalMaterial();
+        const mesh = new THREE.Mesh(geometry, material);
+        scene.add(mesh);
+    });
+}
+function generate(){
+    const desc = document.getElementById('desc').value;
+    fetch('/generate', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({description: desc})
+    }).then(r=>r.json()).then(data=>{
+        if(data.error){alert(data.error);return;}
+        loadSTL(data.preview);
+        const link = document.getElementById('download');
+        link.href = data.step;
+        link.style.display = 'block';
+    }).catch(err=>alert(err));
+}
+init();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build Flask app to parse simple shape descriptions into STEP files
- render 3D preview via three.js
- ignore generated outputs

## Testing
- `python3 -m py_compile app.py`
- `curl -s http://localhost:5000 | head`
- `curl -s -X POST -H 'Content-Type: application/json' -d '{"description":"cube 10 10 10"}' http://localhost:5000/generate`

------
https://chatgpt.com/codex/tasks/task_e_685608cc532c832da1e4efdfb6fa5a5f